### PR TITLE
Add detect duplicate feature

### DIFF
--- a/src/main/java/helpbuddy/command/AddCommand.java
+++ b/src/main/java/helpbuddy/command/AddCommand.java
@@ -29,9 +29,14 @@ public class AddCommand extends Command {
      */
     @Override
     public String execute(TaskList taskList, Ui ui, Storage storage) {
-        taskList.addTask(this.task);
-        return ui.printAddTaskMessage(this.task, taskList);
+        if (taskList.hasDuplicate(task)) {
+            return ui.printTaskDuplicateMessage();
+        } else {
+            taskList.addTask(this.task);
+            return ui.printAddTaskMessage(this.task, taskList);
+        }
     }
+
 
     /**
      * Compares the object to the specified object. The result is true if and only if argument is not null and

--- a/src/main/java/helpbuddy/task/TaskList.java
+++ b/src/main/java/helpbuddy/task/TaskList.java
@@ -71,4 +71,20 @@ public class TaskList {
         }
         return commonTaskList;
     }
+
+    /**
+     * Checks if the new Task to be added is already in TaskList.
+     * @param newTask a Task object to be added.
+     * @return true if Task is already added, else false.
+     */
+    public boolean hasDuplicate(Task newTask) {
+        boolean isEqual = false;
+        for (Task task : this.taskList) {
+            if (newTask.equals(task)) {
+                isEqual = true;
+                break;
+            }
+        }
+        return isEqual;
+    }
 }

--- a/src/main/java/helpbuddy/ui/Ui.java
+++ b/src/main/java/helpbuddy/ui/Ui.java
@@ -108,4 +108,11 @@ public class Ui {
         return "Please enter the start/end time in the format of <DD/MM/YY HH:MM>!";
     }
 
+    /**
+     * Returns a String that informs users about duplicate task.
+     * @return a String message that signals to user that the task has been added.
+     */
+    public String printTaskDuplicateMessage() {
+        return "This task has already been added to your task list.";
+    }
 }


### PR DESCRIPTION
HelpBuddy allows users to add tasks with the same details repeatedly into the task list.

Before adding any task that user inputs, there will be a check to ensure that this task is not present in the task list.

This removes clutter arising from duplicate tasks when users want to see a list of their saved tasks.